### PR TITLE
Inserted additional dependencies to the installer script.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,1 @@
 web: pserve development.ini --reload
-high_queue: rq worker high
-low_queue: rq worker low

--- a/scripts/install_spotify_depends.sh
+++ b/scripts/install_spotify_depends.sh
@@ -23,8 +23,10 @@ function package_status() {
 
 package_status 'build-essential'
 package_status 'lame'
+package_status 'python-dev'
 package_status 'python-virtualenv'
 package_status 'wget'
+package_status 'libffi-dev'
 
 wget https://developer.spotify.com/download/libspotify/libspotify-12.1.51-Linux-x86_64-release.tar.gz -O /tmp/libspotify.tar.gz
 cd /tmp


### PR DESCRIPTION
Upon further investigation, the RQ workers do not properly shut down on
exiting honcho, this leads me to beleive the forking behavior of the
processes make it a non-ideal candidates for honcho management. This
will be reverted for now and reintroduced later when python-rq has been
patched to allow non-daemon mode workers.