### PR TITLE
Isolated queues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,5 @@
-web: pserve development.ini --reload
-# high_queue: rq worker high
-# low_queue: rq worker low
+web: pserve production.ini
+youtube_queue: python -u worker-queues.py youtube
+soundcloud_queue: python -u worker-queues.py soundcloud
+spotify_queue: python -u worker-queues.py spotify
+metadata_queue: python -u worker-queues.py high

--- a/bitlist/db/cache.py
+++ b/bitlist/db/cache.py
@@ -3,9 +3,9 @@
 # Redis Connection agent/manager - because having redis littered around my
 # code was OBNOXIOUS
 
-from os import environ
+from os import getenv
 from redis import Redis
-
+import urlparse
 
 # Redis DB schema
 # 0 / Job Data
@@ -18,12 +18,16 @@ from redis import Redis
 class Cache:
 
     def __init__(self):
-        redis_dsn = environ['REDIS_HOST']
-        self.redis_host = redis_dsn.split(':')[0]
-        self.redis_port = redis_dsn.split(':')[1]
+        redis_dsn = getenv('REDIS_URL')
+        if not redis_dsn:
+            raise RuntimeError('Setup Redis first.')
+
+        urlparse.uses_netloc.append('redis')
+        url = urlparse.urlparse(redis_dsn)
+        self.host = url.hostname
+        self.port = url.port
+        self.password = url.password
 
     def connection(self, database=0):
-        return Redis(host=self.redis_host, port=self.redis_port, db=database)
-
-
+        return Redis(host=self.host, port=self.port, db=database, password=self.password)
 

--- a/bitlist/downloader/soundcloud.py
+++ b/bitlist/downloader/soundcloud.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 import logging
+from mutagen.easyid3 import EasyID3
+from mutagen.mp3 import MP3
 import shlex
 from subprocess import check_call
 
@@ -11,8 +13,16 @@ def download_url(url, temp_directory='/tmp'):
     # I hate this...
     check_call(shlex.split(cmd))
     scrub_filenames(temp_directory)
+    embed_metadata(temp_directory, url)
     return temp_directory
 
 def scrub_filenames(temp_directory):
     for f in temp_directory.files():
         f.rename(f.replace(' ', '_'))
+
+def embed_metadata(filepath, url):
+    for mp3 in filepath.files('*.mp3'):
+        audiofile = MP3(mp3, ID3=EasyID3)
+        audiofile.tags['website'] = url
+        audiofile.tags.save()
+        print "Updated audio file with {}".format(audiofile.tags)

--- a/bitlist/downloader/spotify.py
+++ b/bitlist/downloader/spotify.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 import logging
 import shlex
+from mutagen.easyid3 import EasyID3
+from mutagen.mp3 import MP3
 from subprocess import check_call
 from os import environ
 
@@ -10,13 +12,21 @@ def download_url(url, temp_directory='/tmp'):
     user = environ['SPOTIFY_USER']
     passwd = environ['SPOTIFY_PASS']
     cmd = ".venv/bin/spotify-ripper -k spotify_appkey.key -d {} -u {} -p {}" \
-          " -A -F  {}  ".format(temp_directory, user, passwd, url)
+          " -A -f  {}  ".format(temp_directory, user, passwd, url)
     # I hate this...
     check_call(shlex.split(cmd))
     scrub_filenames(temp_directory)
+    embed_metadata(temp_directory, url)
     return temp_directory
 
 
 def scrub_filenames(temp_directory):
     for f in temp_directory.files():
         f.rename(f.replace(' ', '_'))
+
+def embed_metadata(filepath, url):
+    for mp3 in filepath.files('*.mp3'):
+        audiofile = MP3(mp3, ID3=EasyID3)
+        audiofile.tags['website'] = url
+        audiofile.tags.save()
+        print "Updated audio file with {}".format(audiofile.tags)

--- a/worker-queues.py
+++ b/worker-queues.py
@@ -1,0 +1,19 @@
+import os
+import urlparse
+from redis import Redis
+from rq import Worker, Queue, Connection
+import sys
+
+listen = [sys.argv[1]]
+
+redis_url = os.getenv('REDIS_URL')
+if not redis_url:
+    raise RuntimeError('Setup Redis first.')
+
+urlparse.uses_netloc.append('redis')
+url = urlparse.urlparse(redis_url)
+conn = Redis(host=url.hostname, port=url.port, db=0, password=url.password)
+
+with Connection(conn):
+    worker = Worker(map(Queue, listen))
+    worker.work()


### PR DESCRIPTION
Refactors the job processors for consistency. …
- Adds website metadata to soundcloud/spotify tracks for origin linking
- Added guard against JSON file processing (metadata)	
- Refactored the cache db object to do proper Redis DSN parsing
- adds worker-queues.py to handle spinning up associated queue worker
- Sets bitlist to run from production.ini by default w/ honcho

With this change, there are some one-off cases where the workers can be
left hanging around if the main honcho process tanks and takes the
website with it. As the workers fork to the background - process
management here is tricky. However this is 50% better than just calling
`rq worker [queue]` - as those leave behind workers 100% of the time.